### PR TITLE
Fixed annotation click handler

### DIFF
--- a/src/invidious/views/components/player.ecr
+++ b/src/invidious/views/components/player.ecr
@@ -241,21 +241,20 @@ xhr.onreadystatechange = function () {
 };
 
 window.addEventListener("__ar_annotation_click", e => {
-    const { url, target } = e.detail;
+    const { url, target, seconds } = e.detail;
     
-    var path = new URL(e.detail.url);
+    var path = new URL(url);
+    var finalUrl = path.pathname + path.search
 
-    if (path.href.startsWith("https://www.youtube.com/watch?") && (e.detail.seconds)) {
-        path += "&t=" + e.detail.seconds;
+    if (finalUrl.startsWith("/watch") && seconds) {
+        finalUrl += "&t=" + seconds;
     }
-
-    path  = path.pathname + path.search;
 
     if (target === "current") {
-        window.location.href = path;
+        window.location.href = finalUrl;
     }
     else if (target === "new") {
-        window.open(path, "_blank");
+        window.open(finalUrl, "_blank");
     }
 });
 


### PR DESCRIPTION
Fixes annotation links incorrectly redirecting to the home page

**Example**
Clicking the "Retry" annotation on:

https://dev.invidio.us/watch?annotation_id=annotation_804536&ei=g_IyXPnXLoKIVNeVm6gH&feature=iv&src_vid=TFaK3-by9Kg&v=iRokVZ22Uzg 

currently redirects back to https://dev.invidio.us/